### PR TITLE
Playground HTML fixes

### DIFF
--- a/playground.html
+++ b/playground.html
@@ -1,6 +1,7 @@
 <html lang="en">
 <head>
 
+    <meta charset="UTF-8">
     <title>Playground for Hyper Hyper Space</title>
 
     <script src="https://bundle.run/buffer@6.0.3"></script>

--- a/playground.html
+++ b/playground.html
@@ -1,6 +1,8 @@
 <html lang="en">
 <head>
 
+    <title>Playground for Hyper Hyper Space</title>
+
     <script src="https://bundle.run/buffer@6.0.3"></script>
     <script src="./dist-browser/hhs.js"></script>
 

--- a/playground.html
+++ b/playground.html
@@ -1,4 +1,4 @@
-<html>
+<html lang="en">
 <head>
 
     <script src="https://bundle.run/buffer@6.0.3"></script>

--- a/playground.html
+++ b/playground.html
@@ -117,7 +117,8 @@
 
     <p>
         To create a Document Space, do this (paste this to the console in this page):
-        
+    </p>
+
 <pre>
     await init();
     let ds = new DocumentSpace();
@@ -128,12 +129,14 @@
     ds.startSync()
 </pre>
 
+    <p>
         You only need to run the code above once. The 3-word code for your newly created space will be printed on the console, and the space will be persisted to in-browser storage.
     </p>
 
     <p>
         You can then instantiate this object in another computer / browser / tab (or re-open it in the same browser where you created it) by opening this
         page again and then typing this in the console:
+    </p>
 
 <pre>
     await init();
@@ -144,6 +147,7 @@
     ds.startSync();
 </pre>
 
+    <p>
         Remember to replace the 3-code word in the code above by the one you got when creating your space!
         You need to keep at least one browser tab open for the space to be available.
     </p>
@@ -152,23 +156,21 @@
 <pre>
     ds.setValue({'myApp': 'state'});
 </pre>
-    </p>
 
     <p>
         And you can read that back in the rest of them:
+    </p>
 <pre>
     ds.getValue();
-</pre>  
-    </p>
+</pre>
 
     <p>If you were <b>really</b> creating an HHS-based webpage, you'll probably want to use something like these <a href="https://github.com/hyperhyperspace/hyperhyperspace-react">react bindings</a> to tie your web components automatically to the objects in your store!</p>
 
-    <p>Or maybe you can get away with a callback whenever state changes, something like this:
+    <p>Or maybe you can get away with a callback whenever state changes, something like this:</p>
 
 <pre>
     ds.contents.addMutationCallback(() => {console.log('do something! state has changed!');})
 </pre>
-    </p>
 
     <p> Help / feedback: <a href="https://github.com/hyperhyperspace/hyperhyperspace-core">Github</a>, <a href="https://discord.gg/9epr3XrRnW">Discord</a></p>
 </body>


### PR DESCRIPTION
I just discovered **H<sup>2</sup>Space** and I think its awesome!

Obviously I headed straight over to the playground to mess around with things.
I noticed some of the HTML was a bit wonky, this MR tries to correct some things.

Specifically:

- An HTML document really should have a `lang` attribute.
- A character-set should be declared to help browsers display text correctly
- A title is also nice
- `<pre>` tags should _not_ be wrapped in a `<p>`. As they are both block-level elements, and `<p>` is self-closing, opening a `<pre>` effectively closes ` <p>`, meaning that browsers think this page has a lot of random `</p>`'s (and is missing some `<p>`s as well).

Hope this helps, keep up the good stuff!